### PR TITLE
Update jquery.counterup.js

### DIFF
--- a/jquery.counterup.js
+++ b/jquery.counterup.js
@@ -63,7 +63,6 @@
                 if ($this.data('counterup-nums').length) {
                     setTimeout($this.data('counterup-func'), $settings.delay);
                 } else {
-                    delete $this.data('counterup-nums');
                     $this.data('counterup-nums', null);
                     $this.data('counterup-func', null);
                 }


### PR DESCRIPTION
Removing this should fix this compile error with Google Closure:

JSC_PARSE_ERROR: Parse error. Invalid delete operand. Only properties can be deleted. at line 66 character 0
                    delete $this.data('counterup-nums');

I'm not sure exactly what the delete is supposed to do and if its necessary???