### PR TITLE
Add data-count attribute

### DIFF
--- a/jquery.counterup.js
+++ b/jquery.counterup.js
@@ -26,7 +26,7 @@
         var counterUpper = function() {
             var nums = [];
             var divisions = $settings.time / $settings.delay;
-            var num = $this.text();
+            var num = $(this).attr('data-count') ? $(this).attr('data-count') : $this.text();
             var isComma = /[0-9]+,[0-9]+/.test(num);
             num = num.replace(/,/g, '');
             var isInt = /^[0-9]+$/.test(num);


### PR DESCRIPTION
I'm worried about that visitors see max-value when before domready.
This fix allows to set count value by `data-count` attribute.
Then markup allows to set `0` in innerHTML.
