### PR TITLE
Update jquery.counterup.js for new version of waypoint

### DIFF
--- a/jquery.counterup.js
+++ b/jquery.counterup.js
@@ -72,6 +72,9 @@
 
             // Start the count up
             setTimeout($this.data('counterup-func'), $settings.delay);
+          
+            //Distroy For New Version Of Waypoint
+            this.destroy();
         };
 
         // Perform counts when the element gets into view

--- a/jquery.counterup.js
+++ b/jquery.counterup.js
@@ -78,7 +78,7 @@
         };
 
         // Perform counts when the element gets into view
-        $this.waypoint(counterUpper, { offset: '100%', triggerOnce: true });
+        $this.waypoint(counterUpper, { offset: '100%' });
     });
 
   };


### PR DESCRIPTION
This change recommended for jquery 3.3.1 and new version of waypoint. Because it is support "this.destroy()" function